### PR TITLE
Some small fixes needed for Paratext

### DIFF
--- a/sty/usfm.sty
+++ b/sty/usfm.sty
@@ -90,7 +90,7 @@
 \Italic
 \Bold
 \Color 16384
-\ColorName highcon green
+#!\ColorName highcon green
 
 \Marker toc2
 \Name toc2 - File - Short Table of Contents Text
@@ -103,7 +103,7 @@
 \FontSize 12
 \Italic
 \Color 16384
-\ColorName highcon green
+#!\ColorName highcon green
 
 \Marker toc3
 \Name toc3 - File - Book Abbreviation
@@ -117,7 +117,7 @@
 \Bold
 \Italic
 \Color 128
-\ColorName lowcon red
+#!\ColorName lowcon red
 
 \Marker toca1
 \Name toca1 - File - Alternative Language Long Table of Contents Text
@@ -130,7 +130,7 @@
 \FontSize 10
 \Italic
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 \Marker toca2
 \Name toca2 - File - Alternative Language Short Table of Contents Text
@@ -143,7 +143,7 @@
 \FontSize 10
 \Italic
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 \Marker toca3
 \Name toca3 - File - Alternative Language Book Abbreviation
@@ -156,7 +156,7 @@
 \FontSize 10
 \Italic
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 # Remarks and Comments
 
@@ -169,7 +169,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker sts
 \Name rem - File - Status
@@ -180,7 +180,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker restore
 \Name restore - File - Restore Information
@@ -192,7 +192,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Introduction
 
@@ -671,7 +671,7 @@
 \Italic
 \FontSize 16
 \Color 2263842
-\ColorName green
+#!\ColorName green
 
 \Marker cp
 \Name cp - Chapter Number - Publishing Alternate
@@ -686,7 +686,7 @@
 \SpaceBefore 8
 \SpaceAfter 4
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker cl
 \Name cl - Chapter - Publishing Label
@@ -732,7 +732,7 @@
 \FontSize 12
 \Superscript
 \Color 2263842
-\ColorName green
+#!\ColorName green
 
 \Marker vp
 \Endmarker vp*
@@ -744,7 +744,7 @@
 \FontSize 12
 \Superscript
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Paragraphs
 
@@ -2209,7 +2209,7 @@
 \TextType NoteText
 \StyleType Character
 \FontSize 12
-#!\Attributes link-href
+#!\Attributes ?link-href
 
 \Marker xta
 \Endmarker xta*
@@ -2384,7 +2384,7 @@
 \StyleType Character
 \FontSize 12
 #\Color 2263842
-#\ColorName green
+##!\ColorName green
 \Bold
 \Italic
 \Underline
@@ -2399,7 +2399,7 @@
 \StyleType Character
 \FontSize 12
 \Color 255
-\ColorName highcon red
+#!\ColorName highcon red
 
 \Marker k
 \Endmarker k*
@@ -2444,7 +2444,7 @@
 \TextProperties publishable vernacular
 \StyleType Character
 #\Color 2263842
-#\ColorName green
+##!\ColorName green
 \Bold
 \Italic
 
@@ -2564,7 +2564,7 @@
 \TextType Other
 \StyleType Character
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 \Underline
 #!\Attributes link-href
 
@@ -2655,7 +2655,7 @@
 \SpaceBefore 16
 \SpaceAfter 4
 \Color 33023
-\ColorName orange
+#!\ColorName orange
 
 # Additional peripheral material extensions to existing USFM markup.
 
@@ -2713,7 +2713,7 @@
 \FontSize 12
 \Italic
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker xtSeeAlso
 \Endmarker xtSeeAlso*
@@ -2726,7 +2726,7 @@
 \FontSize 12
 \Italic
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Milestones - these are not compatible with USFM2, so whole entries are preceded with #!
 
@@ -3032,7 +3032,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Concordance/Names Index Tools - special sfms for use in Publishing Assistant
 

--- a/sty/usfm_sb.sty
+++ b/sty/usfm_sb.sty
@@ -90,7 +90,7 @@
 \Italic
 \Bold
 \Color 16384
-\ColorName highcon green
+#!\ColorName highcon green
 
 \Marker toc2
 \Name toc2 - File - Short Table of Contents Text
@@ -103,7 +103,7 @@
 \FontSize 12
 \Italic
 \Color 16384
-\ColorName highcon green
+#!\ColorName highcon green
 
 \Marker toc3
 \Name toc3 - File - Book Abbreviation
@@ -117,7 +117,7 @@
 \Bold
 \Italic
 \Color 128
-\ColorName lowcon red
+#!\ColorName lowcon red
 
 \Marker toca1
 \Name toca1 - File - Alternative Language Long Table of Contents Text
@@ -130,7 +130,7 @@
 \FontSize 10
 \Italic
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 \Marker toca2
 \Name toca2 - File - Alternative Language Short Table of Contents Text
@@ -143,7 +143,7 @@
 \FontSize 10
 \Italic
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 \Marker toca3
 \Name toca3 - File - Alternative Language Book Abbreviation
@@ -156,7 +156,7 @@
 \FontSize 10
 \Italic
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 # Remarks and Comments
 
@@ -169,7 +169,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker sts
 \Name rem - File - Status
@@ -180,7 +180,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker restore
 \Name restore - File - Restore Information
@@ -192,7 +192,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Introduction
 
@@ -439,7 +439,7 @@
 \FontSize 12
 \FirstLineIndent .125   # 1/8 inch first line indent
 \Color 8421504
-\ColorName gray
+#!\ColorName gray
 
 \Marker im
 \Name im - Introduction - Paragraph - no first line indent
@@ -673,7 +673,7 @@
 \Italic
 \FontSize 16
 \Color 2263842
-\ColorName green
+#!\ColorName green
 
 \Marker cp
 \Name cp - Chapter Number - Publishing Alternate
@@ -688,7 +688,7 @@
 \SpaceBefore 8
 \SpaceAfter 4
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker cl
 \Name cl - Chapter - Publishing Label
@@ -734,7 +734,7 @@
 \FontSize 12
 \Superscript
 \Color 2263842
-\ColorName green
+#!\ColorName green
 
 \Marker vp
 \Endmarker vp*
@@ -746,7 +746,7 @@
 \FontSize 12
 \Superscript
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Paragraphs
 
@@ -2470,7 +2470,7 @@
 \TextType NoteText
 \StyleType Character
 \FontSize 12
-#!\Attributes link-href
+#!\Attributes ?link-href
 
 \Marker xta
 \Endmarker xta*
@@ -2612,7 +2612,7 @@
 \StyleType Character
 \FontSize 14
 \Color 8388736
-\ColorName highcon purple
+#!\ColorName highcon purple
 
 # Other Special Text
 
@@ -2714,7 +2714,7 @@
 \StyleType Character
 \FontSize 12
 #\Color 2263842
-#\ColorName green
+##!\ColorName green
 \Bold
 \Italic
 \Underline
@@ -2729,7 +2729,7 @@
 \StyleType Character
 \FontSize 12
 \Color 255
-\ColorName highcon red
+#!\ColorName highcon red
 
 \Marker k
 \Endmarker k*
@@ -2774,7 +2774,7 @@
 \TextProperties publishable vernacular
 \StyleType Character
 #\Color 2263842
-#\ColorName green
+##!\ColorName green
 \Bold
 \Italic
 
@@ -2894,7 +2894,7 @@
 \TextType Other
 \StyleType Character
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 \Underline
 #!\Attributes link-href
 
@@ -2985,7 +2985,7 @@
 \SpaceBefore 16
 \SpaceAfter 4
 \Color 33023
-\ColorName orange
+#!\ColorName orange
 
 # Additional peripheral material extensions to existing USFM markup.
 
@@ -3043,7 +3043,7 @@
 \FontSize 12
 \Italic
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 \Marker xtSeeAlso
 \Endmarker xtSeeAlso*
@@ -3056,7 +3056,7 @@
 \FontSize 12
 \Italic
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Milestones - these are not compatible with USFM2, so whole entries are preceded with #!
 
@@ -3351,7 +3351,7 @@
 \StyleType Paragraph
 \FontSize 12
 \Color 16711680
-\ColorName highcon blue
+#!\ColorName highcon blue
 
 # Concordance/Names Index Tools - special sfms for use in Publishing Assistant
 


### PR DESCRIPTION
Maintain backwards compatibility for \ColorName by making them special comments
Fixed \xt marker attribute not being optional.