### PR TITLE
Add missing line break in sty/README.md

### DIFF
--- a/sty/README.md
+++ b/sty/README.md
@@ -94,6 +94,7 @@ Entries in a USFM stylesheet can contain the following properties. All of these 
 **Property:** `\Superscript`  
 **Example:** `\Superscript`  
 **Description:** Font for this tag is raised.
+
 **Property:** `\TextProperties`  
 **Example:** `\TextProperties paragraph publishable vernacular`  
 **Description:** Should contain one of the following values:


### PR DESCRIPTION
Add the missing line break before `Property: \TextProperties` in the stylesheet readme.