### PR TITLE
Fix name of sts marker

### DIFF
--- a/sty/usfm.sty
+++ b/sty/usfm.sty
@@ -172,7 +172,7 @@
 #!\ColorName highcon blue
 
 \Marker sts
-\Name rem - File - Status
+\Name sts - File - Status
 \Description Status of this file
 \OccursUnder id ide c
 \TextType Other


### PR DESCRIPTION
The name of \sts was "rem", probably a copy-paste error.