### PR TITLE
Enable left-aligned table cells and column headings

### DIFF
--- a/docs/tables/index.rst
+++ b/docs/tables/index.rst
@@ -99,6 +99,16 @@ Numbers 2.10-16 (GNT)
 .. _usfmc_thl#:
 .. index:: marker; \thl#, tables; left aligned table column heading
 
+\\thl#
+^^^^^
+
+:Syntax: ``\thl#_text...``
+:Type: character
+:Added: 3.0
+:Use: Left aligned table column heading. |br|
+	The variable # represents the table column number. |br| |br|
+	|badge_3.0| Use a dash ``-`` between a range of column numbers to indicate that the columns should be spanned.
+
 -----
 
 .. _usfmc_tc#:
@@ -160,6 +170,16 @@ Numbers 2.10-16 (GNT)
 
 .. _usfmc_tcl#:
 .. index:: marker; \tcl#, tables; left aligned table cell
+
+\\tcl#
+^^^^^
+
+:Syntax: ``\tcl#_text...``
+:Type: character
+:Added: 3.0
+:Use: Left aligned table cell. |br|
+	The variable # represents the table column number. |br| |br|
+	|badge_3.0| Use a dash ``-`` between a range of column numbers to indicate that the columns should be spanned.
 
 .. _usfmc_table_colspan:
 .. index:: tables; column span

--- a/docs/tables/index.rst
+++ b/docs/tables/index.rst
@@ -83,6 +83,22 @@ Numbers 2.10-16 (GNT)
 .. image:: images/usfm-character_thr.jpg
 	:width: 250px
 
+.. _usfmc_thc#:
+.. index:: marker; \thc#, tables; center aligned table column heading
+
+\\thc#
+^^^^^
+
+:Syntax: ``\thc#_text...``
+:Type: character
+:Added: 3.0
+:Use: Center aligned table column heading. |br|
+	The variable # represents the table column number. |br| |br|
+	|badge_3.0| Use a dash ``-`` between a range of column numbers to indicate that the columns should be spanned.
+
+.. _usfmc_thl#:
+.. index:: marker; \thl#, tables; left aligned table column heading
+
 -----
 
 .. _usfmc_tc#:
@@ -128,6 +144,22 @@ Numbers 2.10-16 (GNT)
 
 .. image:: images/usfm-character_tc.jpg
 	:width: 250px
+
+.. _usfmc_tcc#:
+.. index:: marker; \tcc#, tables; center aligned table cell
+
+\\tcc#
+^^^^^
+
+:Syntax: ``\tcc#_text...``
+:Type: character
+:Added: 3.0
+:Use: Center aligned table cell. |br|
+	The variable # represents the table column number. |br| |br|
+	|badge_3.0| Use a dash ``-`` between a range of column numbers to indicate that the columns should be spanned.
+
+.. _usfmc_tcl#:
+.. index:: marker; \tcl#, tables; left aligned table cell
 
 .. _usfmc_table_colspan:
 .. index:: tables; column span

--- a/sty/USFMSty-ChangeLog.txt
+++ b/sty/USFMSty-ChangeLog.txt
@@ -1,4 +1,7 @@
 ## ChangeLog for Paratext usfm.sty
+** Update by Hasso Pape Aug 2, 2021
+- Version 2.503
+- Add \thl# and \tcl# markers for left-aligned table cells (useful when a different alignment has been inherited)
 ** Update by Mike Lothers Nov 11, 2015
 - Version 2.502
 - Add f to OccursUnder for \w...\w*

--- a/sty/usfm.sty
+++ b/sty/usfm.sty
@@ -1585,6 +1585,113 @@
 \StyleType Character
 \FontSize 12
 
+# Left Aligned Table Heads and Columns
+
+\Marker thl1
+\Name thl1 - Table - Column 1 Heading - Left Aligned
+\Description A table heading, column 1, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl2
+\Name thl2 - Table - Column 2 Heading - Left Aligned
+\Description A table heading, column 2, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl3
+\Name thl3 - Table - Column 3 Heading - Left Aligned
+\Description A table heading, column 3, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl4
+\Name thl4 - Table - Column 4 Heading - Left Aligned
+\Description A table heading, column 4, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl5
+\Name thl5 - Table - Column 5 Heading - Left Aligned
+\Description A table heading, column 5, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker tcl1
+\Name tcl1 - Table - Column 1 Cell - Left Aligned
+\Description A table cell item, column 1, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl2
+\Name tcl2 - Table - Column 2 Cell - Left Aligned
+\Description A table cell item, column 2, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl3
+\Name tcl3 - Table - Column 3 Cell - Left Aligned
+\Description A table cell item, column 3, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl4
+\Name tcl4 - Table - Column 4 Cell - Left Aligned
+\Description A table cell item, column 4, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl5
+\Name tcl5 - Table - Column 5 Cell - Left Aligned
+\Description A table cell item, column 5, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
 # Center Aligned Table Heads and Columns
 
 \Marker thc1 

--- a/sty/usfm_sb.sty
+++ b/sty/usfm_sb.sty
@@ -1725,6 +1725,176 @@
 \StyleType Character
 \FontSize 12
 
+# Left Aligned Table Heads and Columns
+
+\Marker thl1
+\Name thl1 - Table - Column 1 Heading - Left Aligned
+\Description A table heading, column 1, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl2
+\Name thl2 - Table - Column 2 Heading - Left Aligned
+\Description A table heading, column 2, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl3
+\Name thl3 - Table - Column 3 Heading - Left Aligned
+\Description A table heading, column 3, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl4
+\Name thl4 - Table - Column 4 Heading - Left Aligned
+\Description A table heading, column 4, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl5
+\Name thl5 - Table - Column 5 Heading - Left Aligned
+\Description A table heading, column 5, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl6
+\Name thl6 - Table - Column 6 Heading - Left Aligned
+\Description A table heading, column 6, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl7
+\Name thl7 - Table - Column 7 Heading - Left Aligned
+\Description A table heading, column 7, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker thl8
+\Name thl8 - Table - Column 8 Heading - Left Aligned
+\Description A table heading, column 8, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Left
+
+\Marker tcl1
+\Name tcl1 - Table - Column 1 Cell - Left Aligned
+\Description A table cell item, column 1, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl2
+\Name tcl2 - Table - Column 2 Cell - Left Aligned
+\Description A table cell item, column 2, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl3
+\Name tcl3 - Table - Column 3 Cell - Left Aligned
+\Description A table cell item, column 3, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl4
+\Name tcl4 - Table - Column 4 Cell - Left Aligned
+\Description A table cell item, column 4, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl5
+\Name tcl5 - Table - Column 5 Cell - Left Aligned
+\Description A table cell item, column 5, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl6
+\Name tcl6 - Table - Column 6 Cell - Left Aligned
+\Description A table cell item, column 6, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl7
+\Name tcl7 - Table - Column 7 Cell - Left Aligned
+\Description A table cell item, column 7, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
+\Marker tcl8
+\Name tcl8 - Table - Column 8 Cell - Left Aligned
+\Description A table cell item, column 8, left aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Left
+
 # Center Aligned Table Heads and Columns
 
 \Marker thc1 


### PR DESCRIPTION
Specifying left alignment can be useful when a different alignment has been inherited.