### PR TITLE
Fix typo in erqe marker name

### DIFF
--- a/sty/usfm_sb.sty
+++ b/sty/usfm_sb.sty
@@ -2810,7 +2810,7 @@
 \FontSize 12
 
 \Marker erqe
-\Name erq - Study - Reflective Questions Ending
+\Name erqe - Study - Reflective Questions Ending
 \Description Study Bible reflective questions ending
 \OccursUnder id c erq
 \TextProperties publishable vernacular note


### PR DESCRIPTION
This error is causing confusion for translators localizing the Paratext UI, and could cause confusion for end users as well.