### PR TITLE
Update study bible stylesheet to support 8 column headers

### DIFF
--- a/sty/usfm_sb.sty
+++ b/sty/usfm_sb.sty
@@ -1644,7 +1644,47 @@
 
 \Marker th8
 \Name th8 - Table - Column 8 Heading
-\Description A table heading, column 4
+\Description A table heading, column 8
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th9
+\Name th9 - Table - Column 9 Heading
+\Description A table heading, column 9
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th10
+\Name th10 - Table - Column 10 Heading
+\Description A table heading, column 10
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th11
+\Name th11 - Table - Column 11 Heading
+\Description A table heading, column 11
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th12
+\Name th12 - Table - Column 12 Heading
+\Description A table heading, column 12
 \OccursUnder tr
 \TextType VerseText
 \TextProperties publishable vernacular


### PR DESCRIPTION
We found that column headers were only supporting 8 table headers for study bibles instead of 12 columns like the other column markers.