### PR TITLE
Update usfm stylesheet to support 12 columns to make it consistent

### DIFF
--- a/sty/usfm.sty
+++ b/sty/usfm.sty
@@ -1540,6 +1540,76 @@
 \FontSize 12
 \Italic
 
+\Marker th6
+\Name th6 - Table - Column 6 Heading
+\Description A table heading, column 6
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th7
+\Name th7 - Table - Column 7 Heading
+\Description A table heading, column 7
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th8
+\Name th8 - Table - Column 8 Heading
+\Description A table heading, column 8
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th9
+\Name th9 - Table - Column 9 Heading
+\Description A table heading, column 9
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th10
+\Name th10 - Table - Column 10 Heading
+\Description A table heading, column 10
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th11
+\Name th11 - Table - Column 11 Heading
+\Description A table heading, column 11
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th12
+\Name th12 - Table - Column 12 Heading
+\Description A table heading, column 12
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
 \Marker tc1
 \Name tc1 - Table - Column 1 Cell
 \Description A table cell item, column 1
@@ -1579,6 +1649,69 @@
 \Marker tc5
 \Name tc5 - Table - Column 5 Cell
 \Description A table cell item, column 5
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc6
+\Name tc6 - Table - Column 6 Cell
+\Description A table cell item, column 6
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc7
+\Name tc7 - Table - Column 7 Cell
+\Description A table cell item, column 7
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc8
+\Name tc8 - Table - Column 8 Cell
+\Description A table cell item, column 8
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc9
+\Name tc9 - Table - Column 9 Cell
+\Description A table cell item, column 9
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc10
+\Name tc10 - Table - Column 10 Cell
+\Description A table cell item, column 10
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc11
+\Name tc11 - Table - Column 11 Cell
+\Description A table cell item, column 11
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc12
+\Name tc12 - Table - Column 12 Cell
+\Description A table cell item, column 12
 \OccursUnder tr
 \TextType VerseText
 \TextProperties publishable vernacular
@@ -1642,6 +1775,83 @@
 \Italic
 \Justification Center
 
+\Marker thc6
+\Name thc6 - Table - Column 6 Heading - Center Aligned
+\Description A table heading, column 6, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc7
+\Name thc7 - Table - Column 7 Heading - Center Aligned
+\Description A table heading, column 7, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc8
+\Name thc8 - Table - Column 8 Heading - Center Aligned
+\Description A table heading, column 8, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc9
+\Name thc9 - Table - Column 9 Heading - Center Aligned
+\Description A table heading, column 9, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc10
+\Name thc10 - Table - Column 10 Heading - Center Aligned
+\Description A table heading, column 10, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc11
+\Name thc11 - Table - Column 11 Heading - Center Aligned
+\Description A table heading, column 11, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc12
+\Name thc12 - Table - Column 12 Heading - Center Aligned
+\Description A table heading, column 12, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
 \Marker tcc1
 \Name tcc1 - Table - Column 1 Cell - Center Aligned
 \Description A table cell item, column 1, center aligned
@@ -1685,6 +1895,76 @@
 \Marker tcc5
 \Name tcc5 - Table - Column 5 Cell - Center Aligned
 \Description A table cell item, column 5, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc6
+\Name tcc6 - Table - Column 6 Cell - Center Aligned
+\Description A table cell item, column 6, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc7
+\Name tcc7 - Table - Column 7 Cell - Center Aligned
+\Description A table cell item, column 7, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc8
+\Name tcc8 - Table - Column 8 Cell - Center Aligned
+\Description A table cell item, column 8, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc9
+\Name tcc9 - Table - Column 9 Cell - Center Aligned
+\Description A table cell item, column 9, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc10
+\Name tcc10 - Table - Column 10 Cell - Center Aligned
+\Description A table cell item, column 10, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc11
+\Name tcc11 - Table - Column 11 Cell - Center Aligned
+\Description A table cell item, column 11, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc12
+\Name tcc12 - Table - Column 12 Cell - Center Aligned
+\Description A table cell item, column 12, center aligned
 \OccursUnder tr
 \TextType VerseText
 \TextProperties publishable vernacular
@@ -1749,6 +2029,83 @@
 \Italic
 \Justification Right
 
+\Marker thr6
+\Name thr6 - Table - Column 6 Heading - Right Aligned
+\Description A table heading, column 6, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
+\Marker thr7
+\Name thr7 - Table - Column 7 Heading - Right Aligned
+\Description A table heading, column 7, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
+\Marker thr8
+\Name thr8 - Table - Column 8 Heading - Right Aligned
+\Description A table heading, column 8, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
+\Marker thr9
+\Name thr9 - Table - Column 9 Heading - Right Aligned
+\Description A table heading, column 9, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
+\Marker thr10
+\Name thr10 - Table - Column 10 Heading - Right Aligned
+\Description A table heading, column 10, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
+\Marker thr11
+\Name thr11 - Table - Column 11 Heading - Right Aligned
+\Description A table heading, column 11, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
+\Marker thr12
+\Name thr12 - Table - Column 12 Heading - Right Aligned
+\Description A table heading, column 12, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification right
+
 \Marker tcr1 
 \Name tcr1 - Table - Column 1 Cell - Right Aligned
 \Description A table cell item, column 1, right aligned
@@ -1798,6 +2155,76 @@
 \StyleType Character
 \FontSize 12
 \Justification Right
+
+\Marker tcr6
+\Name tcr6 - Table - Column 6 Cell - Right Aligned
+\Description A table cell item, column 6, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
+
+\Marker tcr7
+\Name tcr7 - Table - Column 7 Cell - Right Aligned
+\Description A table cell item, column 7, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
+
+\Marker tcr8
+\Name tcr8 - Table - Column 8 Cell - Right Aligned
+\Description A table cell item, column 8, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
+
+\Marker tcr9
+\Name tcr9 - Table - Column 9 Cell - Right Aligned
+\Description A table cell item, column 9, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
+
+\Marker tcr10
+\Name tcr10 - Table - Column 10 Cell - Right Aligned
+\Description A table cell item, column 10, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
+
+\Marker tcr11
+\Name tcr11 - Table - Column 11 Cell - Right Aligned
+\Description A table cell item, column 11, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
+
+\Marker tcr12
+\Name tcr12 - Table - Column 12 Cell - Right Aligned
+\Description A table cell item, column 12, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification right
 
 # Lists
 


### PR DESCRIPTION
Update usfm stylesheet to support 12 columns to make it consistent with the study bible stylesheet.  This is a request from Paratext.